### PR TITLE
Clarify Traefik basic auth instructions

### DIFF
--- a/docs/knowledge-base/proxy/traefik/basic-auth.md
+++ b/docs/knowledge-base/proxy/traefik/basic-auth.md
@@ -73,7 +73,7 @@ Then you need to add the middleware to the router label, and since one or more m
 
 For example you would update the current line
 
-`traefik.http.routers.http-0-wc04wo4ow4scokgsw8wow4s8.middlewares=redirect-to-https`
+`traefik.http.routers.https-0-wc04wo4ow4scokgsw8wow4s8.middlewares=gzip`
 
 to:
 


### PR DESCRIPTION
The documentation instructs that the user should re-write the middleware line for Traefik basic auth. However, the docs incorrect use the `http` middleware as the "before" example, when the correct middleware to re-write is the `https` middleware. 

Here's the current incorrect instructions:

![image](https://github.com/user-attachments/assets/583ce56e-1667-437f-8be1-63633092089c)

This PR updates the "before" line to correctly use the `https` middleware, making the instruction to "replace this line" correct.

I attempted this with an incorrect fix previously [here](https://github.com/coollabsio/documentation-coolify/pull/202); see that PR for an explanation of `http` vs `https` middlewares.